### PR TITLE
Allow bulding multiple application from single project based on TARGET_APP environment variable

### DIFF
--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -18,6 +18,10 @@ const appDirectory = fs.realpathSync(process.cwd());
 const resolveApp = relativePath => path.resolve(appDirectory, relativePath);
 
 const envPublicUrl = process.env.PUBLIC_URL;
+
+const targetAppOverridePath = resolveApp(process.env.TARGET_APP + '.paths.json');
+const targetAppOverrides = path.existsSync(targetAppOverridePath) ? require(targetAppOverridePath) : {};
+
 const appPaths = Object.assign({
   dotenv: '.env',
   appBuild:'build',
@@ -29,7 +33,7 @@ const appPaths = Object.assign({
   yarnLockFile: 'yarn.lock',
   testsSetup: 'src/setupTests.js',
   appNodeModules: 'node_modules',
-}, (process.env.APP_PATHS && require(process.env.APP_PATHS)) || {});
+}, targetAppOverrides);
 
 function ensureSlash(path, needsSlash) {
   const hasSlash = path.endsWith('/');

--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -18,6 +18,18 @@ const appDirectory = fs.realpathSync(process.cwd());
 const resolveApp = relativePath => path.resolve(appDirectory, relativePath);
 
 const envPublicUrl = process.env.PUBLIC_URL;
+const appPaths = Object.assign({
+  dotenv: '.env',
+  appBuild:'build',
+  appPublic: 'public',
+  appHtml:'public/index.html',
+  appIndexJs: 'src/index.js',
+  appPackageJson: 'package.json',
+  appSrc: 'src',
+  yarnLockFile: 'yarn.lock',
+  testsSetup: 'src/setupTests.js',
+  appNodeModules: 'node_modules',
+}, (process.env.APP_PATHS && require(process.env.APP_PATHS)) || {});
 
 function ensureSlash(path, needsSlash) {
   const hasSlash = path.endsWith('/');
@@ -48,16 +60,16 @@ function getServedPath(appPackageJson) {
 
 // config after eject: we're in ./config/
 module.exports = {
-  dotenv: resolveApp('.env'),
-  appBuild: resolveApp('build'),
-  appPublic: resolveApp('public'),
-  appHtml: resolveApp('public/index.html'),
-  appIndexJs: resolveApp('src/index.js'),
-  appPackageJson: resolveApp('package.json'),
-  appSrc: resolveApp('src'),
-  yarnLockFile: resolveApp('yarn.lock'),
-  testsSetup: resolveApp('src/setupTests.js'),
-  appNodeModules: resolveApp('node_modules'),
+  dotenv: resolveApp(appPaths.dotenv),
+  appBuild: resolveApp(appPaths.appBuild),
+  appPublic: resolveApp(appPaths.appPublic),
+  appHtml: resolveApp(appPaths.appHtml),
+  appIndexJs: resolveApp(appPaths.appIndexJs),
+  appPackageJson: resolveApp(appPaths.appPackageJson),
+  appSrc: resolveApp(appPaths.appSrc),
+  yarnLockFile: resolveApp(appPaths.yarnLockFile),
+  testsSetup: resolveApp(appPaths.testsSetup),
+  appNodeModules: resolveApp(appPaths.appNodeModules),
   publicUrl: getPublicUrl(resolveApp('package.json')),
   servedPath: getServedPath(resolveApp('package.json')),
 };
@@ -67,17 +79,17 @@ const resolveOwn = relativePath => path.resolve(__dirname, '..', relativePath);
 
 // config before eject: we're in ./node_modules/react-scripts/config/
 module.exports = {
-  dotenv: resolveApp('.env'),
   appPath: resolveApp('.'),
-  appBuild: resolveApp('build'),
-  appPublic: resolveApp('public'),
-  appHtml: resolveApp('public/index.html'),
-  appIndexJs: resolveApp('src/index.js'),
-  appPackageJson: resolveApp('package.json'),
-  appSrc: resolveApp('src'),
-  yarnLockFile: resolveApp('yarn.lock'),
-  testsSetup: resolveApp('src/setupTests.js'),
-  appNodeModules: resolveApp('node_modules'),
+  dotenv: resolveApp(appPaths.dotenv),
+  appBuild: resolveApp(appPaths.appBuild),
+  appPublic: resolveApp(appPaths.appPublic),
+  appHtml: resolveApp(appPaths.appHtml),
+  appIndexJs: resolveApp(appPaths.appIndexJs),
+  appPackageJson: resolveApp(appPaths.appPackageJson),
+  appSrc: resolveApp(appPaths.appSrc),
+  yarnLockFile: resolveApp(appPaths.yarnLockFile),
+  testsSetup: resolveApp(appPaths.testsSetup),
+  appNodeModules: resolveApp(appPaths.appNodeModules),
   publicUrl: getPublicUrl(resolveApp('package.json')),
   servedPath: getServedPath(resolveApp('package.json')),
   // These properties only exist before ejecting:

--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -20,7 +20,7 @@ const resolveApp = relativePath => path.resolve(appDirectory, relativePath);
 const envPublicUrl = process.env.PUBLIC_URL;
 
 const targetAppOverridePath = resolveApp(process.env.TARGET_APP + '.paths.json');
-const targetAppOverrides = path.existsSync(targetAppOverridePath) ? require(targetAppOverridePath) : {};
+const targetAppOverrides = fs.existsSync(targetAppOverridePath) ? require(targetAppOverridePath) : {};
 
 const appPaths = Object.assign({
   dotenv: '.env',

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -236,6 +236,13 @@ module.exports = {
     ],
   },
   plugins: [
+    new webpack.NormalModuleReplacementPlugin(
+      /(.*)\.app(\.*)/,
+      function (resource) {
+        resource.request = resource.request
+          .replace(/.app/, `-${process.env.TARGET_APP}`);
+      }
+    ),
     // Makes some environment variables available in index.html.
     // The public URL is available as %PUBLIC_URL% in index.html, e.g.:
     // <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -237,10 +237,10 @@ module.exports = {
   },
   plugins: [
     new webpack.NormalModuleReplacementPlugin(
-      /(.*)\.app(\.*)/,
+      /(.*)\.TARGET_APP(\.*)/,
       function (resource) {
         resource.request = resource.request
-          .replace(/.app/, `-${process.env.TARGET_APP}`);
+          .replace(/.TARGET_APP/, `.${process.env.TARGET_APP}`);
       }
     ),
     // Makes some environment variables available in index.html.

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -262,10 +262,10 @@ module.exports = {
   },
   plugins: [
     new webpack.NormalModuleReplacementPlugin(
-      /(.*)\.app(\.*)/,
+      /(.*)\.TARGET_APP(\.*)/,
       function (resource) {
         resource.request = resource.request
-          .replace(/.app/, `-${process.env.TARGET_APP}`);
+          .replace(/.TARGET_APP/, `.${process.env.TARGET_APP}`);
       }
     ),
     // Makes some environment variables available in index.html.

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -51,7 +51,7 @@ const cssFilename = 'static/css/[name].[contenthash:8].css';
 // To have this structure working with relative paths, we have to use custom options.
 const extractTextPluginOptions = shouldUseRelativeAssetPaths
   ? // Making sure that the publicPath goes back to to build folder.
-    { publicPath: Array(cssFilename.split('/').length).join('../') }
+  { publicPath: Array(cssFilename.split('/').length).join('../') }
   : {};
 
 // This is the production configuration.
@@ -261,6 +261,13 @@ module.exports = {
     ],
   },
   plugins: [
+    new webpack.NormalModuleReplacementPlugin(
+      /(.*)\.app(\.*)/,
+      function (resource) {
+        resource.request = resource.request
+          .replace(/.app/, `-${process.env.TARGET_APP}`);
+      }
+    ),
     // Makes some environment variables available in index.html.
     // The public URL is available as %PUBLIC_URL% in index.html, e.g.:
     // <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linksoft-react-scripts",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": "stromsky/create-react-app",
   "license": "MIT",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "react-scripts",
-  "version": "1.1.1",
+  "name": "linksoft-react-scripts",
+  "version": "1.0.0",
   "description": "Configuration and scripts for Create React App.",
-  "repository": "facebookincubator/create-react-app",
+  "repository": "stromsky/create-react-app",
   "license": "MIT",
   "engines": {
     "node": ">=6"
   },
   "bugs": {
-    "url": "https://github.com/facebookincubator/create-react-app/issues"
+    "url": "https://github.com/stromsky/create-react-app/issues"
   },
   "files": [
     "bin",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linksoft-react-scripts",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Configuration and scripts for Create React App.",
   "repository": "stromsky/create-react-app",
   "license": "MIT",


### PR DESCRIPTION
When running `react-scripts start` or `react-scripts build` scripts with `TARGET_APP` environment variable, you can override react-scripts' paths by creating `appname.path.json` next to `package.json` file. This allows target different entry point for webpack build. Modified webpack configuration includes `NormalModuleReplacementPlugin` which allows to write module imports generically.

Example:

We have two output apps from single source called AppA and AppB. When we need different implementation for single module used by shared module, we can write import statement this way:

    import customModule from './custom-module.TARGET_APP;

Now we just need to create JS files for each application: `custom-module.AppA.js` and `custom-module.AppB.js` and that's it. When building target application, webpack will include only those modules relevant to targeted application.

